### PR TITLE
Disabling AOT due to $$__genDir error and adding 

### DIFF
--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -4,7 +4,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 import { TabsModule, ButtonsModule } from 'ng2-bootstrap';
 
-import { SelectModule } from 'ng-next-select';
+import { SelectModule } from '../../../src/select/select.module';
 import { AppComponent } from './app.component';
 import { SelectSectionComponent } from './components/select-section';
 import { ChildrenDemoComponent } from './components/select/children-demo';

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build": "ngm build -p src --clean",
     "build.watch": "ngm build -p src --watch --skip-bundles",
     "start": "ng serve --aot",
+    "startNoAot": "ng serve",
     "pretest": "run-s lint build link",
     "test": "ng test -sr",
     "test-coverage": "ng test -sr -cc",


### PR DESCRIPTION
Me and a contributor are getting an error and are unsure of how to get around it

```
Error: Can't resolve './$$_gendir/app/app.module.ngfactory' in .. app.module
```

If anyone can find a solution we would appreciate it but for now we're going to import select.module directly and recommend starting this locally with `npm run startNoAot`